### PR TITLE
Fix go-dqlite tutorial display issues

### DIFF
--- a/tutorials/create-an-example-application.md
+++ b/tutorials/create-an-example-application.md
@@ -1,10 +1,6 @@
-# Create an example application
-
 In the following steps, we will gradually build a minimal `go-dqlite` application that provides an HTTP endpoint to read and write values in a Dqlite cluster.
 
-[note type="important" status="Info"]
- You can find the final code here: https://github.com/canonical/go-dqlite/blob/master/cmd/dqlite-demo/dqlite-demo.go  <!-- wokeignore:rule=master --> 
-[/note]
+>You can find the final code here: https://github.com/canonical/go-dqlite/blob/master/cmd/dqlite-demo/dqlite-demo.go  <!-- wokeignore:rule=master --> 
 
 ## Create a minimal starting point
 
@@ -84,9 +80,7 @@ ubuntu@dqlite-tutorial:~/go-dqlite-demo$ go run go-dqlite-demo.go
 2023/09/11 14:40:46 Table created
 ```
 
-[note type="important" status="Info"]
- Rerunning this app will result in an error since the table already exists. 
-[/note]
+>Rerunning this app will result in an error since the table already exists. 
 
 Congratulations! You have created your first Dqlite application in Go.
 
@@ -97,9 +91,7 @@ A cluster of nodes can simply be created by providing the IP address of the lead
 In the previous example, we hard-coded the address directly in the code. Each node needs a unique IP address, so we need to make this value configurable.
 Let's use [Cobra](https://github.com/spf13/cobra) to turn the previous example into a CLI application to which we can pass flags.
 
-[note type="important" status="Info"]
- An introduction to Cobra is out of scope for this tutorial. Visit the [official documentation](https://cobra.dev/#getting-started) for more information on this library.
-[/note]
+>An introduction to Cobra is out of scope for this tutorial. Visit the [official documentation](https://cobra.dev/#getting-started) for more information on this library.
 
 Install the dependency with:
 ```bash
@@ -270,9 +262,7 @@ signal.Notify(ch, unix.SIGQUIT)
 signal.Notify(ch, unix.SIGTERM)
 ```
 
-[note type="important" status="Info"]
- Read more on [HTTP servers in Go](https://pkg.go.dev/net/http).
-[/note]
+>Read more on [HTTP servers in Go](https://pkg.go.dev/net/http).
 
 Finally, add an `api` flag that defines the address of the HTTP API. The final code looks like this:
 

--- a/tutorials/setup-your-development-environment.md
+++ b/tutorials/setup-your-development-environment.md
@@ -1,5 +1,3 @@
-# Set up your development environment
-
 The following section walks you through the necessary steps to set up your environment.
 It is recommended to spin up a clean Ubuntu VM for these steps as it is always good to perform experiments in an isolated development environment.
 Follow the steps in [Set up an Ubuntu VM with Multipass](https://juju.is/docs/sdk/set-up-your-development-environment#heading--set-up-an-ubuntu-vm-with-multipass) to do this.
@@ -29,9 +27,7 @@ Then install the library:
 sudo apt install libdqlite-dev
 ```
 
-[note type="important" status="Info"]
-If you are not using a Debian-based system, you must build `libdqlite` from source. See [Build](https://github.com/canonical/dqlite#build) for instructions on how to do this.
-[/note]
+>If you are not using a Debian-based system, you must build `libdqlite` from source. See [Build](https://github.com/canonical/dqlite#build) for instructions on how to do this.
 
 # Install Go 
 
@@ -55,9 +51,7 @@ Install the application bindings for `go-dqilite/app` with:
 go get github.com/canonical/go-dqlite/app
 ```
 
-[note type="important" status="Info"]
-Read more about Go mod files in the [Go documentation](https://go.dev/ref/mod).
-[/note]
+>Read more about Go mod files in the [Go documentation](https://go.dev/ref/mod).
 
 # Install a C compiler
 


### PR DESCRIPTION
* Removes headers in markdown files as they will automatically be generated
* Replace markdown notes with quotes as they seem not to be supported by the dqlite discourse instance.

The tutorial is now correctly displayed: https://dqlite.io/docs/tutorials/get-started-with-dqlite-in-go

(Creating a PR instead of directly pushing to `main` since I'm missing the access rights.)